### PR TITLE
fix: fix and optimize contents in Chapter 1

### DIFF
--- a/Chaps/Chap1.tex
+++ b/Chaps/Chap1.tex
@@ -102,7 +102,7 @@
  \end{cases}
  \label{eq:1.7}
 \end{equation}
-其中 $\delta_ij$ 为 Kronecker delta 函数。
+其中 $\delta_{ij}$ 为 Kronecker delta 函数。
 上式是基矢\emph{正交归一}性质的数学描述：
 基矢之间互相垂直（正交），
 并且具有单位长度（归一）。 
@@ -336,7 +336,7 @@ $M$个数的集合$\left\{a_i\right\}, i = 1, 2, \dots, M$可以类似地看做�
 我们注意到，如果$\mbf a$和$\mbf b$均为实矩阵且$M$值为3时，
 上式即为两个三维矢量的标量积。
 对\autoref{eq:1.24}两边分别取其伴随矩阵，
-并引用练习~\autoref{ex:1.3} 的结论，
+并引用\autoref{ex:1.3} 的结论，
 我们得到如下关系：
 \begin{equation}
  {\mbf b}^\dagger = {\mbf a}^\dagger {\mbf A}^\dagger
@@ -480,7 +480,7 @@ $p_i$为由标准排列 $1, 2, 3, \dots, N$ 到一个给定的排列 $i_1, i_2, 
  \end{enumerate}
 \Next
  对照\autoref{eq:1.39}，
- 我们发现在练习 \autoref{ex:1.4}f 中得到的$2\times 2$矩阵 $\mbf A$的逆可以写作：
+ 我们发现在\autoref{ex:1.4}f 中得到的$2\times 2$矩阵 $\mbf A$的逆可以写作：
  \[{\mbf A}^{-1} = \frac{1}{\vert\mbf{A}\vert}
  \begin{vmatrix*}[r]
      A_{22} & -A_{12} \\ -A_{21} & A_{11}
@@ -647,7 +647,7 @@ c_2 \begin{vmatrix}
 \end{subequations}
 从上面两式可以得到：
 \begin{equation}
- \mbf{a} = \sum_i \ket{i}\bra{i}
+ \mbf{1} = \sum_i \ket{i}\bra{i}
  \label{eq:1.51}
 \end{equation}
 即为$N$维空间基组的完备性关系，
@@ -749,12 +749,12 @@ Hermitian算符矩阵表示的矩阵元满足如下关系：
 这样，我们有：
 \begin{subequations}
  \begin{equation}
-     \olp{i}{j} = \delta_{ij}, \qquad\sum_i \oup{i}{i} = 1
+     \olp{i}{j} = \delta_{ij}, \qquad\sum_i \oup{i}{i} = \mbf{1}
      \label{eq:1.62a}
  \end{equation}
 以及
 \begin{equation}
- \olp{\alpha}{\beta} = \delta_{\alpha\beta}, \qquad \sum_{\alpha}\oup{\alpha}{\alpha} = 1
+ \olp{\alpha}{\beta} = \delta_{\alpha\beta}, \qquad \sum_{\alpha}\oup{\alpha}{\alpha} = \mbf{1}
  \label{eq:1.62b}
 \end{equation}
 \end{subequations}
@@ -762,7 +762,7 @@ Hermitian算符矩阵表示的矩阵元满足如下关系：
 我们可以将基组$\kbs{\alpha}$中的任一基矢$\ket{\alpha}$展开为基组$\kbs{i}$中基矢的线性组合，
 反之亦然。即：
 \begin{equation}
- \ket{\alpha} = 1\ket{\alpha} = \sum_i\ket{i}\olp{i}{\alpha} = \sum_i \ket{i}U_{i\alpha} = \sum_i \ket{i}\left(\mbf U\right)_{i\alpha}
+ \ket{\alpha} = \mbf{1}\ket{\alpha} = \sum_i\ket{i}\olp{i}{\alpha} = \sum_i \ket{i}U_{i\alpha} = \sum_i \ket{i}\left(\mbf U\right)_{i\alpha}
  \label{eq:1.63}
 \end{equation}
 其中，变换矩阵$\mbf U$的矩阵元定义为：
@@ -772,7 +772,7 @@ Hermitian算符矩阵表示的矩阵元满足如下关系：
 \end{equation}
 对于反向的变换，我们有：
 \begin{equation}
- \ket{i} = 1\ket{i} = \sum_{\alpha}\ket{\alpha}\olp{\alpha}{i} = \sum_{\alpha} \ket{\alpha}U_{i\alpha}^\ast = \sum_{\alpha} \ket{\alpha}\left(\madj{U}\right)_{\alpha i}
+ \ket{i} = \mbf{1}\ket{i} = \sum_{\alpha}\ket{\alpha}\olp{\alpha}{i} = \sum_{\alpha} \ket{\alpha}U_{i\alpha}^\ast = \sum_{\alpha} \ket{\alpha}\left(\madj{U}\right)_{\alpha i}
  \label{eq:1.65}
 \end{equation}
 上式中我们用到了\autoref{eq:1.49}和伴随矩阵的定义，
@@ -1021,7 +1021,7 @@ New York, 1965. 这是本领域的一本经典参考书。
  \end{equation}
  \label{eq:1.84}
 \end{subequations}
-在练习~\autoref{ex:1.7} 中我们看到，\autoref{eq:1.84b}只有在满足
+在\autoref{ex:1.7} 中我们看到，\autoref{eq:1.84b}只有在满足
 \begin{equation}
  \left\vert\mbf{O}-\omega\mbf{1}\right\vert = 0
  \label{eq:1.85}
@@ -1031,7 +1031,7 @@ New York, 1965. 这是本领域的一本经典参考书。
 是一个关于未知数$\omega$的$N$次多项式。
 一个$N$次多项式具有$N$个根$\omega_\alpha,\; \alpha = 1, 2, \dots, N$，
 即为矩阵$\mbf O$的$N$个本征值。
-将每一个本征值$\omega_\alpha$代入\autoref{eq:1.84}，
+将每一个本征值$\omega_\alpha$代入\autoref{eq:1.84a}，
 求解关于$\mbf c$的线性方程组，
 所得结果$\mbf{c}^\alpha$就是本征值$\omega_\alpha$对应的本征矢。
 这样除一个常数因子之外，
@@ -1042,7 +1042,7 @@ New York, 1965. 这是本领域的一本经典参考书。
  \label{eq:1.86}
 \end{equation}
 通过这种方法，
-我们可以求得\autoref{eq:1.84}的$N$个解：
+我们可以求得\autoref{eq:1.84a}的$N$个解：
 \begin{equation}
  \mbf{O}\mbf{c}^\alpha = \omega_\alpha \mbf{c}^\alpha, \qquad \alpha = 1, 2, \dots, N
  \label{eq:1.87}
@@ -1068,7 +1068,7 @@ New York, 1965. 这是本领域的一本经典参考书。
  \end{pmatrix}
  \label{eq:1.89}
 \end{equation}
-可以看到，矩阵$\mbf U$的第$\alpha$列就是列矩阵$\mbf{c^\alpha}$。
+可以看到，矩阵$\mbf U$的第$\alpha$列就是列矩阵$\mbf{c}^\alpha$。
 结合\autoref{eq:1.87}，我们得到：
 \begin{equation}
  \mbf{OU} = \mbf{U} \begin{pmatrix}
@@ -1376,7 +1376,7 @@ $N\times N$矩阵对角化的 Jacobi 方法就是这个计算步骤的一个推�
 所以：
 \begin{equation}
  \begin{split}
-     f\left(\mbf{A}\right) = \sum_0^{\infty} &= \begin{pmatrix}
+     f\left(\mbf{A}\right) = \sum_0^{\infty}c_n \mbf{A}^n &= \begin{pmatrix}
       \sum_n c_n a_1^n &               &      & \\
                      &\sum_n c_n a_2^n &\mathbf{0} & \\
                &\mathbf{0} &\ddots & \\
@@ -1417,7 +1417,9 @@ $N\times N$矩阵对角化的 Jacobi 方法就是这个计算步骤的一个推�
  \label{eq:1.113}
 \end{subequations}
 我们注意到
-\[\mbf{A}^2 = \mbf{Ua}\madj{U}\mbf{Ua}\madj{U}\]
+\[
+    \mbf{A}^2 = \mbf{Ua}\madj{U}\mbf{Ua}\madj{U} = \mbf{U} \mbf{a}^2 \madj{U}
+\]
 或者更普遍的，有：
 \begin{equation}
  \mbf{A}^n = \mbf{U}\mbf{a}^n \madj{U}
@@ -1453,11 +1455,11 @@ $N\times N$矩阵对角化的 Jacobi 方法就是这个计算步骤的一个推�
 比如，矩阵$\mbf A$有一个本征值为零（$a_i = 0$），
 则 $f(a_i) = 1/a_i = \infty$，
 此时$\mbf{A}^{-1}$不存在。
-练习~\autoref{ex:1.12}a 证明了一个矩阵$\mbf A$的行列式等于其所有本征值的乘积。
+\autoref{ex:1.12}a 证明了一个矩阵$\mbf A$的行列式等于其所有本征值的乘积。
 因此，只要$\mbf A$的本征值中含有零，
 $\det(\mbf A)$即为零，
 从而导致$\mbf{A}^{-1}$不存在。
-练习~\autoref{ex:1.7} 通过另一种方法也得到了同样的结果。
+\autoref{ex:1.7} 通过另一种方法也得到了同样的结果。
 
 \exercise{
  已知：
@@ -1475,11 +1477,11 @@ $\det(\mbf A)$即为零，
      \item $\mrm{tr}\,\mbf{A}^n = \sum_{\alpha=1}^N a_{\alpha}^n$. 
      \item 如果 $\mbf{G}\left(\omega\right) = \left(\omega\mbf{1}-\mbf{A}\right)^{-1}$，则有
      \[
-     \left(\mbf{G}\left(\omega\right)\right)_{ij} = \sum_{\alpha=1}^N \frac{U_{i\alpha}U_{j\alpha}^\ast}{\omega - \omega_\alpha} = \sum_{\alpha=1}^N \frac{c_i^\alpha c_j^{\alpha\ast}}{\omega-\omega_\alpha}
+     \left(\mbf{G}\left(\omega\right)\right)_{ij} = \sum_{\alpha=1}^N \frac{U_{i\alpha}U_{j\alpha}^\ast}{\omega - a_\alpha} = \sum_{\alpha=1}^N \frac{c_i^\alpha c_j^{\alpha\ast}}{\omega-a_\alpha}
      \]
      用 Dirac 符号将上式重写成如下形式：
      \[
-     \left(\mbf{G}\left(\omega\right)\right)_{ij} \equiv \left\langle i\middle\vert \op{G}\left(\omega\right)\middle\vert j\right\rangle = \sum_\alpha \frac{\olp{i}{\alpha}\olp{\alpha}{j}}{\omega-\omega_\alpha}
+     \left(\mbf{G}\left(\omega\right)\right)_{ij} \equiv \left\langle i\middle\vert \op{G}\left(\omega\right)\middle\vert j\right\rangle = \sum_\alpha \frac{\olp{i}{\alpha}\olp{\alpha}{j}}{\omega-a_\alpha}
      \]
      作为上式的一个有趣的应用，我们考虑一个非齐次线性方程的求解问题：
      \[
@@ -1493,7 +1495,7 @@ $\det(\mbf A)$即为零，
      则需要对\emph{每个} $\omega$都进行一次矩阵求逆。
      然而，如果我们将$\mbf A$对角化，则可以写成：
      \[
-     x_i = \sum_j \left(\mbf{G}\left(\omega\right)\right)_{ij} c_j = \sum_{j\alpha}\frac{U_{i\alpha}U_{j\alpha}^\ast c_j}{\omega-\omega_\alpha}
+     x_i = \sum_j \left(\mbf{G}\left(\omega\right)\right)_{ij} c_j = \sum_{j\alpha}\frac{U_{i\alpha}U_{j\alpha}^\ast c_j}{\omega-a_\alpha}
      \]
      这样将大大简化关于$\omega$的函数$\mbf{x}$的求算。
  \end{enumerate}
@@ -1545,7 +1547,7 @@ $\det(\mbf A)$即为零，
 \end{equation}
 将上式带入初始的展开\autoref{eq:1.117}，则有：
 \begin{equation}
- a(x) = \int \mrm{d}x^\prime\left[\sum_i\psi_i(x)\psi_j^\ast(x^\prime)\right]a\left(x^\prime\right)
+ a(x) = \int \mrm{d}x^\prime\left[\sum_i\psi_i(x)\psi_i^\ast(x^\prime)\right]a\left(x^\prime\right)
  \label{eq:1.119}
 \end{equation}
 上式方括号中的量是$x$和$x^\prime$的函数，
@@ -1761,7 +1763,7 @@ Dirac 符号的优美之处在于，它允许我们用完全相同的形式来�
  \[\phi(x) = \sum_i^\infty c_i \psi_i(x)\]
  证明等价于矩阵的本征值问题：
  \[\mbf{O}\mbf{c} = \omega\mbf{c}\]
- 此处，$(\mbf{c}_i) = c_i$，$(\mbf{O})_{ij} = \int\mrm{d}x\,psi_i^\ast(x)\psi_j(x)$。
+ 此处，$(\mbf{c}_i) = c_i$，$(\mbf{O})_{ij} = \int\mrm{d}x \psi_i^\ast(x) \op{O} \psi_j(x)$。
  分别用普通形式和 Dirac 符号完成以上证明。
  需要注意的是，此处$\mbf{O}$是一个无穷矩阵，
  而实际操作中，我们无法处理无穷矩阵。
@@ -1806,12 +1808,12 @@ $\olp{a}{x}$即$a^\ast(x)$，$\olp{x}{b}$即$b(x)$。
 因此，
 我们可以将函数$b(x)$看做是抽象矢量$\ket{b}$在一个具有连续变量的无限多坐标轴的坐标系中沿$x$的分量。
 \begin{enumerate}[a.]
- \item 将\autoref{eq:e1.17.2a}两边左乘$\bra{i}$，右乘$\ket{j}$，应用\autoref{eq:e1.17.1b}，若有如下关系成立：
+ \item 将\autoref{eq:e1.17.2a}两边左乘$\bra{i}$，右乘$\ket{j}$，应用\autoref{eq:e1.17.1b}，证明若有如下关系成立：
  \[
  \psi^\ast_i(x) = \olp{i}{x} \qquad \psi_j(x) = \olp{x}{j}
  \]
  则所得结果与\autoref{eq:1.116}等同。
- \item 将\autoref{eq:e1.17.1a}两边左乘$\bra{x}$，右乘$\ket{x^\prime}$。若有如下关系成立
+ \item 将\autoref{eq:e1.17.1a}两边左乘$\bra{x}$，右乘$\ket{x^\prime}$。证明若有如下关系成立
  \[
  \olp{x}{x^\prime} = \delta(x - x^\prime)
  \tag{2b} \label{eq:e1.17.2b}
@@ -2132,7 +2134,7 @@ Hamiltonian 算符在基组$\left\{\vert\Psi_i\rangle\right\}$中的矩阵表示
  \label{eq:1.171}
 \end{equation}
 那么其他本征值$E$有什么物理意义呢？
-可以证明（见练习~\autoref{ex:1.21}）
+可以证明（见\autoref{ex:1.21}）
 $E_\alpha \geq \mcr{E}_\alpha,\, \alpha = 1, 2, \dots$，因此，$E_1$是第一激发态能量的上限，以此类推。
 
 \exercise{

--- a/Chaps/Chap1.tex
+++ b/Chaps/Chap1.tex
@@ -1823,7 +1823,7 @@ $\olp{a}{x}$即$a^\ast(x)$，$\olp{x}{b}$即$b(x)$。
  \item 一个算符$\op{O}$在连续基$\ket{x}$中的矩阵表示为
  \[\Mele{x}{O}{x^\prime} = O(x, x^\prime)\]
  由式$\op{O}\ket{a} = \ket{b}$出发并插入完备性关系，我们有
- \[\op{O}\ket{a} = \op{O}\mbf{1}\ket{a} \int\mrm{d}x\,\op{O}\ket{x}\bra{x}\ket{a} = \ket{b}\]
+ \[\op{O}\ket{a} = \op{O}\mbf{1}\ket{a} = \int\mrm{d}x\,\op{O}\ket{x}\bra{x}\ket{a} = \ket{b}\]
  将上式左乘$\bra{x^\prime}$，验证结果与\autoref{eq:1.133}等同。
  \item 若有$O_{ij} = \Mele{i}{O}{j}$，验证：
  \[O(x,x^\prime) = \sum_{ij}\psi_i(x)O_{ij}\psi_j^\ast(x)\]
@@ -1901,23 +1901,21 @@ $\ket{\Phi}$是波函数，$\op{E}$是体系能量。
 \end{equation}
 此定理的证明比较简单。首先我们考虑
 \begin{equation}
- \begin{split}
-     \Olp{\tilde\Phi}{\tilde\Phi} &= 1 = \sum_{\alpha\beta}\Big\langle\tilde\Phi\Big\vert\Phi_\alpha\Big\rangle\Big\langle\Phi_\alpha\Big\vert\Phi_\beta\Big\rangle\Big\langle\Phi_\beta\Big\vert\tilde\Phi\Big\rangle = \sum_{\alpha\beta} \Big\langle\tilde\Phi\Big\vert\Phi_\alpha\Big\rangle\delta_{\alpha\beta}\Big\langle\Phi_\beta\Big\vert\tilde\Phi\Big\rangle \\
-     &= \sum_\alpha \Big\langle\tilde\Phi\Big\vert\Phi_\alpha\Big\rangle\Big\langle\Phi_\alpha\Big\vert\tilde\Phi\Big\rangle = \sum_\alpha \Big\vert\Big\langle\Phi_\alpha\Big\vert\tilde\Phi\Big\rangle\Big\vert^2
- \end{split}
+    \Langle\tilde\Phi\Lvert\tilde\Phi\Rangle = \sum_\alpha \Big\langle\tilde\Phi\Big\vert\Phi_\alpha\Big\rangle\Big\langle\Phi_\alpha\Big\vert\tilde\Phi\Big\rangle = \sum_\alpha \Big\vert\Big\langle\Phi_\alpha\Big\vert\tilde\Phi\Big\rangle\Big\vert^2 = 1
  \label{eq:1.150}
 \end{equation}
-其中，我们用到了\autoref{eq:1.144}、\autoref{eq:1.146}和\autoref{eq:1.147}。然后，
+其中，我们用到了\autoref{eq:1.146}。然后，
 \begin{equation}
- \Langle\tilde\Phi\Lvert\op{H}\Lvert\tilde\Phi\Rangle = \sum_{\alpha\beta}\Langle\tilde\Phi\Lvert\Phi_\alpha\Rangle\Langle\Phi_\alpha\Lvert\op{H}\Lvert\Phi_\beta\Rangle\Langle\Phi_\beta\Lvert\tilde\Phi\Rangle = \sum_\alpha \mcr{E}_\alpha \Lvert\Langle\Phi_\alpha\Lvert\tilde\Phi\Rangle\Lvert^2
+ \Langle\tilde\Phi\Lvert\op{H}\Lvert\tilde\Phi\Rangle = \sum_{\alpha}\Langle\tilde\Phi\Lvert\op{H}\Lvert\Phi_\alpha\Rangle\Langle\Phi_\alpha\Lvert\tilde\Phi\Rangle = \sum_\alpha \mcr{E}_\alpha \Lvert\Langle\Phi_\alpha\Lvert\tilde\Phi\Rangle\Lvert^2
  \label{eq:1.151}
 \end{equation}
-上式用到了\autoref{eq:1.145}。最后，由于对于所有$\alpha$有$\mcr{E}_\alpha \geq \mcr{E}_0$，我们得到
+上式用到了\autoref{eq:1.143}。最后，由于对于所有$\alpha$有$\mcr{E}_\alpha \geq \mcr{E}_0$，我们得到
 \begin{equation}
  \Langle\tilde\Phi\Lvert\op{H}\Lvert\tilde\Phi\Rangle \geq \sum_\alpha \mcr{E}_0\Lvert\Langle\Phi_\alpha\Lvert\tilde\Phi\Rangle\Lvert^2 = \mcr{E}_0\sum_\alpha \Lvert\Langle\Phi_\alpha\Lvert\tilde\Phi\Rangle\Lvert^2 = \mcr{E}_0
  \label{eq:1.152}
 \end{equation}
 此处我们用到了正交化条件\autoref{eq:1.150}。
+% 英文原书中对变分原理的证明非常冗余，其实根本不需要另一套基底\beta，这里我进行了一些简化，应该会更容易阅读与理解
 
 关于基态的变分原理告诉我们，
 近似波函数的能量总是过高。
@@ -2015,7 +2013,7 @@ Hamiltonian 算符在基组$\left\{\vert\Psi_i\rangle\right\}$中的矩阵表示
 基函数为实函数，$\mbf H$为对称矩阵，
 即$H_{ij} = H_{ji}$。试探函数满足归一化条件
 \begin{equation}
- \Olp{\tilde\Phi}{\tilde\Phi} = \sum_{ij}\Langle\Psi_i\Lvert\Psi_j\Rangle = \sum_i c_i^2 = 1
+ \Olp{\tilde\Phi}{\tilde\Phi} = \sum_{ij} c_i c_j \Langle\Psi_i\Lvert\Psi_j\Rangle = \sum_i c_i^2 = 1
  \label{eq:1.156}
 \end{equation}
 其期望值
@@ -2063,10 +2061,10 @@ Hamiltonian 算符在基组$\left\{\vert\Psi_i\rangle\right\}$中的矩阵表示
 \end{equation}
 因此，
 \begin{equation}
- \frac{\partial \mcr{L}}{\partial c_k} = 0 = \sum_j c_j H_{kj} + \sum_i c_i H_{ik} - 2 Ec_k
+ \frac{\partial \mcr{L}}{\partial c_k} = 0 = \sum_j c_j H_{kj} + \sum_i c_i H_{ik} - 2 E c_k
  \label{eq:1.162}
 \end{equation}
-又因为 $H_{ij = H_{ji}}$，我们有：
+又因为 $H_{ij} = H_{ji}$，我们有：
 \begin{equation}
  \sum_j H_{ij}c_j - Ec_i = 0
  \label{eq:1.163}
@@ -2153,7 +2151,7 @@ $E_\alpha \geq \mcr{E}_\alpha,\, \alpha = 1, 2, \dots$，因此，$E_1$是第一
      则可由 (a) 得出$\mele{\tilde\Phi^\prime}{H}{\tilde\Phi^\prime} \geq \mcr{E}_1$。
      验证如下关系：
      \[\Mele{\tilde\Phi^\prime}{H}{\tilde\Phi^\prime} = E_1 - \vert x\vert^2 (E_1 - E_0) \]
-     由于$E_1 \geq \mcr{E}_0$，我们可以得到结论$E_1 \geq \mcr{E}_1$。推广以上论证，证明$E_\alpha \geq \mcr{E}_\alpha,\, \alpha = 2, 3, \dots .$
+     由于$E_1 \geq E_0$，我们可以得到结论$E_1 \geq \Mele{\tilde\Phi^\prime}{H}{\tilde\Phi^\prime} \geq \mcr{E}_1$。推广以上论证，证明$E_\alpha \geq \mcr{E}_\alpha,\, \alpha = 2, 3, \dots .$
  \end{enumerate}
 }
 
@@ -2195,7 +2193,7 @@ $E_\alpha \geq \mcr{E}_\alpha,\, \alpha = 1, 2, \dots$，因此，$E_1$是第一
  \sum_j H_{ij}c_j = E c_i
  \label{eq:1.176}
 \end{equation}
-上式的矩阵式与\autoref{eq:1.174}等同。
+上式的矩阵式与\autoref{eq:1.173}等同。
 如果使用\emph{完备}的正交归一基组 $\left\{\ket{\Psi_i},
 \right. \, i = 1, 2,\allowbreak \dots, N, N+1, \left.\dots \right\}$，
 我们则会得到一个与\autoref{eq:1.173}等同，
@@ -2227,6 +2225,7 @@ $E_\alpha \geq \mcr{E}_\alpha,\, \alpha = 1, 2, \dots$，因此，$E_1$是第一
  \]
  其中$\alpha$为体系近似的偶极极化率，验证其值为 2.96。其精确结果为 4.5。
 }
+%Todo 这一道题有些奇怪，很容易验证$<1s|1s> = 1/2, <2pz|2pz> = 1/32$并不归一，但是由于英文原版如此，我也没有做修改。之后有时间可以重新算一下这道题，把这道题的系数改正确。
  
 \addcontentsline{toc}{section}{\protect\numberline{}{扩展阅读}}
  

--- a/Chaps/Chap1.tex
+++ b/Chaps/Chap1.tex
@@ -1899,23 +1899,41 @@ $\ket{\Phi}$是波函数，$\op{E}$是体系能量。
  \Big\langle\tilde\Phi\Big\vert\op{H}\Big\vert\tilde\Phi\Big\rangle \geq \mcr{E}_0
  \label{eq:1.149}
 \end{equation}
-此定理的证明比较简单。首先我们考虑
+此定理的证明比较简单
+\footnote{
+译注：此处原书的证明有些冗余，实际上证明变分定理无需第二套基底$\Ket{\Phi_\beta}$。考虑
+\[
+    \Olp{\tilde\Phi}{\tilde\Phi} = \sum_\alpha \Big\langle\tilde\Phi\Big\vert\Phi_\alpha\Big\rangle\Big\langle\Phi_\alpha\Big\vert\tilde\Phi\Big\rangle = \sum_\alpha \Big\vert\Big\langle\Phi_\alpha\Big\vert\tilde\Phi\Big\rangle\Big\vert^2 = 1
+\]
+上式用到了\autoref{eq:1.146}。然后，
+\[
+    \Langle\tilde\Phi\Lvert\op{H}\Lvert\tilde\Phi\Rangle =  \sum_\alpha \mcr{E}_\alpha \Lvert\Langle\Phi_\alpha\Lvert\tilde\Phi\Rangle\Lvert^2
+\]
+上式用到了\autoref{eq:1.143}。最后，对于所有$\alpha$有$\mcr{E}_\alpha \geq \mcr{E}_0$，我们得到
+\[
+    \Langle\tilde\Phi\Lvert\op{H}\Lvert\tilde\Phi\Rangle = \sum_\alpha \mcr{E}_\alpha\Lvert\Langle\Phi_\alpha\Lvert\tilde\Phi\Rangle\Lvert^2 \geq \sum_\alpha \mcr{E}_0\Lvert\Langle\Phi_\alpha\Lvert\tilde\Phi\Rangle\Lvert^2 = \mcr{E}_0\sum_\alpha \Lvert\Langle\Phi_\alpha\Lvert\tilde\Phi\Rangle\Lvert^2 = \mcr{E}_0
+\]
+即可证明\autoref{eq:1.149}，即变分原理。
+}
+。首先我们考虑
 \begin{equation}
-    \Langle\tilde\Phi\Lvert\tilde\Phi\Rangle = \sum_\alpha \Big\langle\tilde\Phi\Big\vert\Phi_\alpha\Big\rangle\Big\langle\Phi_\alpha\Big\vert\tilde\Phi\Big\rangle = \sum_\alpha \Big\vert\Big\langle\Phi_\alpha\Big\vert\tilde\Phi\Big\rangle\Big\vert^2 = 1
+ \begin{split}
+     \Olp{\tilde\Phi}{\tilde\Phi} &= 1 = \sum_{\alpha\beta}\Big\langle\tilde\Phi\Big\vert\Phi_\alpha\Big\rangle\Big\langle\Phi_\alpha\Big\vert\Phi_\beta\Big\rangle\Big\langle\Phi_\beta\Big\vert\tilde\Phi\Big\rangle = \sum_{\alpha\beta} \Big\langle\tilde\Phi\Big\vert\Phi_\alpha\Big\rangle\delta_{\alpha\beta}\Big\langle\Phi_\beta\Big\vert\tilde\Phi\Big\rangle \\
+     &= \sum_\alpha \Big\langle\tilde\Phi\Big\vert\Phi_\alpha\Big\rangle\Big\langle\Phi_\alpha\Big\vert\tilde\Phi\Big\rangle = \sum_\alpha \Big\vert\Big\langle\Phi_\alpha\Big\vert\tilde\Phi\Big\rangle\Big\vert^2
+ \end{split}
  \label{eq:1.150}
 \end{equation}
-其中，我们用到了\autoref{eq:1.146}。然后，
+其中，我们用到了\autoref{eq:1.144}、\autoref{eq:1.146}和\autoref{eq:1.147}。然后，
 \begin{equation}
- \Langle\tilde\Phi\Lvert\op{H}\Lvert\tilde\Phi\Rangle = \sum_{\alpha}\Langle\tilde\Phi\Lvert\op{H}\Lvert\Phi_\alpha\Rangle\Langle\Phi_\alpha\Lvert\tilde\Phi\Rangle = \sum_\alpha \mcr{E}_\alpha \Lvert\Langle\Phi_\alpha\Lvert\tilde\Phi\Rangle\Lvert^2
+ \Langle\tilde\Phi\Lvert\op{H}\Lvert\tilde\Phi\Rangle = \sum_{\alpha\beta}\Langle\tilde\Phi\Lvert\Phi_\alpha\Rangle\Langle\Phi_\alpha\Lvert\op{H}\Lvert\Phi_\beta\Rangle\Langle\Phi_\beta\Lvert\tilde\Phi\Rangle = \sum_\alpha \mcr{E}_\alpha \Lvert\Langle\Phi_\alpha\Lvert\tilde\Phi\Rangle\Lvert^2
  \label{eq:1.151}
 \end{equation}
-上式用到了\autoref{eq:1.143}。最后，由于对于所有$\alpha$有$\mcr{E}_\alpha \geq \mcr{E}_0$，我们得到
+上式用到了\autoref{eq:1.145}。最后，由于对于所有$\alpha$有$\mcr{E}_\alpha \geq \mcr{E}_0$，我们得到
 \begin{equation}
  \Langle\tilde\Phi\Lvert\op{H}\Lvert\tilde\Phi\Rangle \geq \sum_\alpha \mcr{E}_0\Lvert\Langle\Phi_\alpha\Lvert\tilde\Phi\Rangle\Lvert^2 = \mcr{E}_0\sum_\alpha \Lvert\Langle\Phi_\alpha\Lvert\tilde\Phi\Rangle\Lvert^2 = \mcr{E}_0
  \label{eq:1.152}
 \end{equation}
 此处我们用到了正交化条件\autoref{eq:1.150}。
-% 英文原书中对变分原理的证明非常冗余，其实根本不需要另一套基底\beta，这里我进行了一些简化，应该会更容易阅读与理解
 
 关于基态的变分原理告诉我们，
 近似波函数的能量总是过高。
@@ -2225,7 +2243,6 @@ $E_\alpha \geq \mcr{E}_\alpha,\, \alpha = 1, 2, \dots$，因此，$E_1$是第一
  \]
  其中$\alpha$为体系近似的偶极极化率，验证其值为 2.96。其精确结果为 4.5。
 }
-%Todo 这一道题有些奇怪，很容易验证$<1s|1s> = 1/2, <2pz|2pz> = 1/32$并不归一，但是由于英文原版如此，我也没有做修改。之后有时间可以重新算一下这道题，把这道题的系数改正确。
  
 \addcontentsline{toc}{section}{\protect\numberline{}{扩展阅读}}
  

--- a/main.tex
+++ b/main.tex
@@ -1,7 +1,7 @@
 %!TEX TS-program = xelatex
 %!TEX encoding = UTF-8 Unicode
 
-\documentclass[UTF8,scheme=chinese,heading,openany]{ctexbook}
+\documentclass[UTF8,scheme=chinese,heading]{ctexbook}
 
 %\linespread{1.2}
 

--- a/main.tex
+++ b/main.tex
@@ -1,7 +1,7 @@
 %!TEX TS-program = xelatex
 %!TEX encoding = UTF-8 Unicode
 
-\documentclass[UTF8,scheme=chinese,heading]{ctexbook}
+\documentclass[UTF8,scheme=chinese,heading,openany]{ctexbook}
 
 %\linespread{1.2}
 

--- a/structure.tex
+++ b/structure.tex
@@ -61,16 +61,6 @@
   subsection/format = \fontsize{8pt}{\baselineskip}\selectfont\bfseries\raggedright
 }
 
-% 引用章节、方程、图、表时自动写成“第……章（节）”、“式(x.y)”、“图x.y”、“表x.y”这样的型式：
-\def\chapterautorefname~#1\null{第#1章\null}
-\def\sectionautorefname~#1\null{小节#1\null}
-\def\subsectionautorefname~#1\null{小节#1\null}
-\def\subsubsectionautorefname~#1\null{小节#1\null}
-\def\equationautorefname~#1\null{式(#1)\null}
-\def\tableautorefname~#1\null{表#1\null}
-\def\figureautorefname~#1\null{图#1\null}
-\def\appendixautorefname~#1\null{附录#1\null}
-
 %-----------------------------------------------------------------
 %	Page Headers
 %-----------------------------------------------------------------
@@ -134,6 +124,19 @@
 
 \newcommand\Next{\endXercise\hrule\Xercise\label{ex:\theXercise}}
 \newcommand{\exercise}[1]{\begin{xercise}#1\end{xercise}}
+%----------------------------------------------------------------------------------------
+
+% 引用章节、方程、图、表时自动写成“第……章（节）”、“式(x.y)”、“图x.y”、“表x.y”这样的型式：
+\def\chapterautorefname~#1\null{第#1章\null}
+\def\sectionautorefname~#1\null{小节#1\null}
+\def\subsectionautorefname~#1\null{小节#1\null}
+\def\subsubsectionautorefname~#1\null{小节#1\null}
+\def\equationautorefname~#1\null{式(#1)\null}
+\def\tableautorefname~#1\null{表#1\null}
+\def\figureautorefname~#1\null{图#1\null}
+\def\appendixautorefname~#1\null{附录#1\null}
+\def\Xerciseautorefname~#1\null{练习#1\null}
+
 %========================================================
 
 \newcommand{\tu}{\begin{figure}[h]


### PR DESCRIPTION
我阅读了第一章的内容，对里面公式与内容的一些错误进行了修改和优化。其中有关[变分原理证明的部分](https://github.com/PramSin/szaboqc/blob/master/Chaps/Chap1.tex#L1900)，我认为原书写的比较冗余，其实无需使用另一套基底，因此进行了不同于英文原书的修改。此外，我还添加了适用于练习 `Xercise` 的\autoref命令，删除了章节之间出现的空页。