### PR TITLE
fix: wrong translation in Exercise 1.8

### DIFF
--- a/Chaps/Chap1.tex
+++ b/Chaps/Chap1.tex
@@ -867,7 +867,7 @@ Hermitian算符矩阵表示的矩阵元满足如下关系：
 在下一小节中，我们将要考虑怎样通过幺正变换将Hermitian矩阵对角化。
 
 \exercise{
- 证明：幺正变换后，矩阵的秩不变。
+ 证明：幺正变换后，矩阵的迹不变。
  即，若
  \[\boldsymbol\Omega = \madj{U}\mbf{O}\mbf{U}\]
  则有 $\tr{\boldsymbol\Omega} = \tr{\mbf O}$

--- a/Chaps/Chap1.tex
+++ b/Chaps/Chap1.tex
@@ -358,7 +358,7 @@ $M$个数的集合$\left\{a_i\right\}, i = 1, 2, \dots, M$可以类似地看做�
      \label{eq:1.31}
  \end{equation}
  
- \item 矩阵$\mbf A$的\emph{秩}是其全部对角元的加和：
+ \item 矩阵$\mbf A$的\emph{迹}是其全部对角元的加和：
  \begin{equation}
      \tr{\mbf A} = \sum_i A_{ii}
      \label{eq:1.32}


### PR DESCRIPTION
原文为trace of a matrix，应译为迹